### PR TITLE
Allow icons in data-action element

### DIFF
--- a/src/VdtnetTable.vue
+++ b/src/VdtnetTable.vue
@@ -506,7 +506,7 @@ export default {
       e.preventDefault()
       e.stopPropagation()
 
-      let target = jq(e.target)
+      let target = jq(e.currentTarget)
       let action = target.attr('data-action')
 
       // no action, simply exit


### PR DESCRIPTION
Use e.currentTarget instead of e.target in the data-action element click handler to allow icons or nested html in the target element.